### PR TITLE
Add support for "multipath=off" and "nompath" on kernel cmdline

### DIFF
--- a/multipath/multipath.rules
+++ b/multipath/multipath.rules
@@ -3,6 +3,11 @@ SUBSYSTEM!="block", GOTO="end_mpath"
 ACTION!="add|change", GOTO="end_mpath"
 KERNEL!="sd*|dasd*", GOTO="end_mpath"
 
+IMPORT{cmdline}="nompath"
+ENV{nompath}=="?*", GOTO="end_mpath"
+IMPORT{cmdline}="multipath"
+ENV{multipath}=="off", GOTO="end_mpath"
+
 ENV{DEVTYPE}!="partition", GOTO="test_dev"
 IMPORT{parent}="DM_MULTIPATH_DEVICE_PATH"
 ENV{DM_MULTIPATH_DEVICE_PATH}=="1", ENV{ID_FS_TYPE}="none", \

--- a/multipathd/multipathd.service
+++ b/multipathd/multipathd.service
@@ -6,6 +6,8 @@ Before=local-fs-pre.target blk-availability.service
 After=multipathd.socket systemd-udev-trigger.service systemd-udev-settle.service
 DefaultDependencies=no
 Conflicts=shutdown.target
+ConditionKernelCommandLine=!nompath
+ConditionKernelCommandLine=!multipath=off
 
 [Service]
 Type=notify


### PR DESCRIPTION
The multipathd.service file coming with dracut 044 has support for
"nompath". This should be implemented in the multipath-tools
service file too, and in the udev rules file.