### PR TITLE
Sles12 sp2: accumulated fixes

### DIFF
--- a/libmultipath/config.h
+++ b/libmultipath/config.h
@@ -36,6 +36,12 @@ enum mpath_cmds {
 	CMD_ADD_WWID,
 };
 
+enum force_reload_types {
+	FORCE_RELOAD_NONE,
+	FORCE_RELOAD_YES,
+	FORCE_RELOAD_WEAK,
+};
+
 struct hwentry {
 	char * vendor;
 	char * product;

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -390,6 +390,7 @@ select_action (struct multipath * mpp, vector curmp, int force_reload)
 {
 	struct multipath * cmpp;
 	struct multipath * cmpp_by_name;
+	char * mpp_feat, * cmpp_feat;
 
 	cmpp = find_mp_by_wwid(curmp, mpp->wwid);
 	cmpp_by_name = find_mp_by_alias(curmp, mpp->alias);
@@ -450,11 +451,11 @@ select_action (struct multipath * mpp, vector curmp, int force_reload)
 			mpp->alias);
 		return;
 	}
-	if (!mpp->no_path_retry &&
-	    (strlen(cmpp->features) != strlen(mpp->features) ||
-	     strcmp(cmpp->features, mpp->features))) {
+
+	if (mpp->no_path_retry != NO_PATH_RETRY_UNDEF &&
+	    mpp->no_path_retry != cmpp->no_path_retry) {
 		mpp->action =  ACT_RELOAD;
-		condlog(3, "%s: set ACT_RELOAD (features change)",
+		condlog(3, "%s: set ACT_RELOAD (no_path_retry change)",
 			mpp->alias);
 		return;
 	}
@@ -467,6 +468,31 @@ select_action (struct multipath * mpp, vector curmp, int force_reload)
 			mpp->alias);
 		return;
 	}
+
+	if (mpp->retain_hwhandler != RETAIN_HWHANDLER_UNDEF &&
+	    mpp->retain_hwhandler != cmpp->retain_hwhandler) {
+		mpp->action = ACT_RELOAD;
+		condlog(3, "%s: set ACT_RELOAD (retain_hwhandler change)",
+			mpp->alias);
+		return;
+	}
+
+	cmpp_feat = STRDUP(cmpp->features);
+	mpp_feat = STRDUP(mpp->features);
+	if (cmpp_feat && mpp_feat) {
+		remove_feature(&mpp_feat, "queue_if_no_path");
+		remove_feature(&mpp_feat, "retain_attached_hw_handler");
+		remove_feature(&cmpp_feat, "queue_if_no_path");
+		remove_feature(&cmpp_feat, "retain_attached_hw_handler");
+		if (strncmp(mpp_feat, cmpp_feat, PARAMS_SIZE)) {
+			mpp->action =  ACT_RELOAD;
+			condlog(3, "%s: set ACT_RELOAD (features change)",
+				mpp->alias);
+		}
+	}
+	FREE(cmpp_feat);
+	FREE(mpp_feat);
+
 	if (!cmpp->selector || strncmp(cmpp->selector, mpp->selector,
 		    strlen(mpp->selector))) {
 		mpp->action = ACT_RELOAD;

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -747,6 +747,13 @@ out:
 	return ret;
 }
 
+/*
+ * The force_reload parameter determines how coalesce_paths treats existing maps.
+ * FORCE_RELOAD_NONE: existing maps aren't touched at all
+ * FORCE_RELOAD_YES: all maps are rebuilt from scratch and (re)loaded in DM
+ * FORCE_RELOAD_WEAK: existing maps are compared to the current conf and only
+ * reloaded in DM if there's a difference. This is useful during startup.
+ */
 extern int
 coalesce_paths (struct vectors * vecs, vector newmp, char * refwwid, int force_reload, enum mpath_cmds cmd)
 {
@@ -766,7 +773,7 @@ coalesce_paths (struct vectors * vecs, vector newmp, char * refwwid, int force_r
 	if (refwwid && !strlen(refwwid))
 		refwwid = NULL;
 
-	if (force_reload) {
+	if (force_reload != FORCE_RELOAD_NONE) {
 		vector_foreach_slot (pathvec, pp1, k) {
 			pp1->mpp = NULL;
 		}
@@ -853,7 +860,8 @@ coalesce_paths (struct vectors * vecs, vector newmp, char * refwwid, int force_r
 		if (cmd == CMD_DRY_RUN)
 			mpp->action = ACT_DRY_RUN;
 		if (mpp->action == ACT_UNDEF)
-			select_action(mpp, curmp, force_reload);
+			select_action(mpp, curmp,
+				      force_reload == FORCE_RELOAD_YES ? 1 : 0);
 
 		r = domap(mpp, params, is_daemon);
 

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -406,6 +406,18 @@ get_udev_for_mpp(const struct multipath *mpp)
 	return udd;
 }
 
+static void
+trigger_udev_change(const struct multipath *mpp)
+{
+	static const char change[] = "change";
+	struct udev_device *udd = get_udev_for_mpp(mpp);
+	if (!udd)
+		return;
+	condlog(3, "triggering %s uevent for %s", change, mpp->alias);
+	sysfs_attr_set_value(udd, "uevent", change, sizeof(change)-1);
+	udev_device_unref(udd);
+}
+
 static int
 is_mpp_known_to_udev(const struct multipath *mpp)
 {
@@ -943,6 +955,18 @@ coalesce_paths (struct vectors * vecs, vector newmp, char * refwwid, int force_r
 		}
 		if (r == DOMAP_DRY)
 			continue;
+
+		if (r == DOMAP_EXIST && mpp->action == ACT_NOTHING &&
+		    force_reload == FORCE_RELOAD_WEAK)
+			/*
+			 * First time we're called, and no changes applied.
+			 * domap() was a noop. But we can't be sure that
+			 * udev has already finished setting up this device
+			 * (udev in initrd may have been shut down while
+			 * processing this device or its children).
+			 * Trigger a change event, just in case.
+			 */
+			trigger_udev_change(find_mp_by_wwid(curmp, mpp->wwid));
 
 		conf = get_multipath_config();
 		allow_queueing = conf->allow_queueing;

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -39,6 +39,7 @@
 #include "util.h"
 #include "uxsock.h"
 #include "wwids.h"
+#include "sysfs.h"
 
 /* group paths in pg by host adapter
  */
@@ -385,6 +386,35 @@ pgcmp (struct multipath * mpp, struct multipath * cmpp)
 	return r;
 }
 
+static struct udev_device *
+get_udev_for_mpp(const struct multipath *mpp)
+{
+	dev_t devnum;
+	struct udev_device *udd;
+
+	if (!mpp || !mpp->dmi) {
+		condlog(1, "%s called with empty mpp", __func__);
+		return NULL;
+	}
+
+	devnum = makedev(mpp->dmi->major, mpp->dmi->minor);
+	udd = udev_device_new_from_devnum(udev, 'b', devnum);
+	if (!udd) {
+		condlog(1, "failed to get udev device for %s", mpp->alias);
+		return NULL;
+	}
+	return udd;
+}
+
+static int
+is_mpp_known_to_udev(const struct multipath *mpp)
+{
+	struct udev_device *udd = get_udev_for_mpp(mpp);
+	int ret = (udd != NULL);
+	udev_device_unref(udd);
+	return ret;
+}
+
 static void
 select_action (struct multipath * mpp, vector curmp, int force_reload)
 {
@@ -521,6 +551,12 @@ select_action (struct multipath * mpp, vector curmp, int force_reload)
 	if (cmpp->nextpg != mpp->bestpg) {
 		mpp->action = ACT_SWITCHPG;
 		condlog(3, "%s: set ACT_SWITCHPG (next path group change)",
+			mpp->alias);
+		return;
+	}
+	if (!is_mpp_known_to_udev(cmpp)) {
+		mpp->action = ACT_RELOAD;
+		condlog(3, "%s: set ACT_RELOAD (udev device not initialized)",
 			mpp->alias);
 		return;
 	}

--- a/libmultipath/configure.c
+++ b/libmultipath/configure.c
@@ -459,13 +459,13 @@ select_action (struct multipath * mpp, vector curmp, int force_reload)
 		/* reset alias to existing alias */
 		FREE(mpp->alias);
 		mpp->alias = STRDUP(cmpp->alias);
-		mpp->action = ACT_NOTHING;
+		mpp->action = ACT_IMPOSSIBLE;
 		return;
 	}
 
 	if (pathcount(mpp, PATH_UP) == 0) {
-		mpp->action = ACT_NOTHING;
-		condlog(3, "%s: set ACT_NOTHING (no usable path)",
+		mpp->action = ACT_IMPOSSIBLE;
+		condlog(3, "%s: set ACT_IMPOSSIBLE (no usable path)",
 			mpp->alias);
 		return;
 	}
@@ -668,6 +668,7 @@ domap (struct multipath * mpp, char * params, int is_daemon)
 	switch (mpp->action) {
 	case ACT_REJECT:
 	case ACT_NOTHING:
+	case ACT_IMPOSSIBLE:
 		return DOMAP_EXIST;
 
 	case ACT_SWITCHPG:

--- a/libmultipath/configure.h
+++ b/libmultipath/configure.h
@@ -20,6 +20,7 @@ enum actions {
 	ACT_RESIZE,
 	ACT_FORCERENAME,
 	ACT_DRY_RUN,
+	ACT_IMPOSSIBLE,
 };
 
 #define FLUSH_ONE 1

--- a/libmultipath/devmapper.h
+++ b/libmultipath/devmapper.h
@@ -24,12 +24,12 @@ int dm_get_map(const char *, unsigned long long *, char *);
 int dm_get_status(char *, char *);
 int dm_type(const char *, char *);
 int dm_is_mpath(const char *);
-int _dm_flush_map (const char *, int, int);
+int _dm_flush_map (const char *, int, int, int);
 int dm_flush_map_nopaths(const char * mapname, int deferred_remove);
-#define dm_flush_map(mapname) _dm_flush_map(mapname, 1, 0)
-#define dm_flush_map_nosync(mapname) _dm_flush_map(mapname, 0, 0)
+#define dm_flush_map(mapname) _dm_flush_map(mapname, 1, 0, 0)
+#define dm_flush_map_nosync(mapname) _dm_flush_map(mapname, 0, 0, 0)
+#define dm_suspend_and_flush_map(mapname) _dm_flush_map(mapname, 1, 0, 1)
 int dm_cancel_deferred_remove(struct multipath *mpp);
-int dm_suspend_and_flush_map(const char * mapname);
 int dm_flush_maps (void);
 int dm_fail_path(char * mapname, char * path);
 int dm_reinstate_path(char * mapname, char * path);

--- a/libmultipath/dmparser.c
+++ b/libmultipath/dmparser.c
@@ -385,19 +385,17 @@ disassemble_map (vector pathvec, char * params, struct multipath * mpp,
 
 			for (k = 0; k < num_paths_args; k++)
 				if (k == 0) {
+					p += get_word(p, &word);
+					def_minio = atoi(word);
+					FREE(word);
+
 					if (!strncmp(mpp->selector,
 						     "round-robin", 11)) {
-						p += get_word(p, &word);
-						def_minio = atoi(word);
 
 						if (mpp->rr_weight == RR_WEIGHT_PRIO
 						    && pp->priority > 0)
 							def_minio /= pp->priority;
 
-						FREE(word);
-					} else {
-						p += get_word(p, NULL);
-						def_minio = 0;
 					}
 
 					if (def_minio != mpp->minio)

--- a/libmultipath/dmparser.c
+++ b/libmultipath/dmparser.c
@@ -184,10 +184,7 @@ disassemble_map (vector pathvec, char * params, struct multipath * mpp,
 			FREE(word);
 			return 1;
 		}
-		if ((mpp->no_path_retry == NO_PATH_RETRY_UNDEF) ||
-			(mpp->no_path_retry == NO_PATH_RETRY_FAIL) ||
-			(mpp->no_path_retry == NO_PATH_RETRY_QUEUE))
-			setup_feature(mpp, word);
+		setup_feature(mpp, word);
 
 		FREE(word);
 	}

--- a/libmultipath/print.c
+++ b/libmultipath/print.c
@@ -996,7 +996,7 @@ snprint_multipath_topology (char * buff, int len, struct multipath * mpp,
 
 	if (verbosity > 1 &&
 	    mpp->action != ACT_NOTHING &&
-	    mpp->action != ACT_UNDEF)
+	    mpp->action != ACT_UNDEF && mpp->action != ACT_IMPOSSIBLE)
 			c += sprintf(c, "%%A: ");
 
 	c += sprintf(c, "%%n");

--- a/libmultipath/propsel.c
+++ b/libmultipath/propsel.c
@@ -297,7 +297,9 @@ out:
 			condlog(1, "%s: config error, overriding 'no_path_retry' value",
 				mp->alias);
 			mp->no_path_retry = NO_PATH_RETRY_QUEUE;
-		}
+		} else if (mp->no_path_retry != NO_PATH_RETRY_QUEUE)
+			condlog(1, "%s: config error, ignoring 'queue_if_no_path' because no_path_retry=%d",
+				mp->alias, mp->no_path_retry);
 	}
 	return 0;
 }

--- a/libmultipath/structs.c
+++ b/libmultipath/structs.c
@@ -504,6 +504,9 @@ setup_feature(struct multipath * mpp, char *feature)
 	if (!strncmp(feature, "queue_if_no_path", 16)) {
 		if (mpp->no_path_retry <= NO_PATH_RETRY_UNDEF)
 			mpp->no_path_retry = NO_PATH_RETRY_QUEUE;
+		else
+			condlog(1, "%s: ignoring feature queue_if_no_path because no_path_retry = %d",
+				mpp->alias, mpp->no_path_retry);
 	}
 }
 

--- a/libmultipath/structs.c
+++ b/libmultipath/structs.c
@@ -507,6 +507,12 @@ setup_feature(struct multipath * mpp, char *feature)
 		else
 			condlog(1, "%s: ignoring feature queue_if_no_path because no_path_retry = %d",
 				mpp->alias, mpp->no_path_retry);
+	} else if (!strcmp(feature, "retain_attached_hw_handler")) {
+		if (mpp->retain_hwhandler != RETAIN_HWHANDLER_OFF)
+			mpp->retain_hwhandler = RETAIN_HWHANDLER_ON;
+		else
+			condlog(1, "%s: ignoring feature 'retain_attached_hw_handler'",
+				mpp->alias);
 	}
 }
 

--- a/libmultipath/sysfs.c
+++ b/libmultipath/sysfs.c
@@ -154,7 +154,7 @@ ssize_t sysfs_bin_attr_get_value(struct udev_device *dev, const char *attr_name,
 }
 
 ssize_t sysfs_attr_set_value(struct udev_device *dev, const char *attr_name,
-			     char * value, size_t value_len)
+			     const char * value, size_t value_len)
 {
 	char devpath[PATH_SIZE];
 	struct stat statbuf;

--- a/libmultipath/sysfs.h
+++ b/libmultipath/sysfs.h
@@ -6,7 +6,7 @@
 #define _LIBMULTIPATH_SYSFS_H
 
 ssize_t sysfs_attr_set_value(struct udev_device *dev, const char *attr_name,
-			     char * value, size_t value_len);
+			     const char * value, size_t value_len);
 ssize_t sysfs_attr_get_value(struct udev_device *dev, const char *attr_name,
 			     char * value, size_t value_len);
 ssize_t sysfs_bin_attr_get_value(struct udev_device *dev, const char *attr_name,

--- a/multipath/main.c
+++ b/multipath/main.c
@@ -575,7 +575,7 @@ main (int argc, char *argv[])
 			}
 			break;
 		case 'r':
-			conf->force_reload = 1;
+			conf->force_reload = FORCE_RELOAD_YES;
 			break;
 		case 'i':
 			conf->ignore_wwids = 1;

--- a/multipath/main.c
+++ b/multipath/main.c
@@ -613,6 +613,16 @@ main (int argc, char *argv[])
 		}
 	}
 
+	/*
+	 * FIXME: new device detection with find_multipaths currently
+	 * doesn't work reliably.
+	 */
+	if (cmd ==  CMD_VALID_PATH &&
+	    conf->find_multipaths && conf->ignore_wwids) {
+		condlog(2, "ignoring -i flag because find_multipath is set in multipath.conf");
+		conf->ignore_wwids = 0;
+	}
+
 	if (getuid() != 0) {
 		fprintf(stderr, "need to be root\n");
 		exit(1);

--- a/multipath/main.c
+++ b/multipath/main.c
@@ -366,7 +366,7 @@ configure (struct config *conf, enum mpath_cmds cmd,
 
 	if (cmd == CMD_LIST_LONG)
 		/* extended path info '-ll' */
-		di_flag |= DI_SYSFS | DI_CHECKER;
+		di_flag |= DI_SYSFS | DI_CHECKER | DI_SERIAL;
 	else if (cmd == CMD_LIST_SHORT)
 		/* minimum path info '-l' */
 		di_flag |= DI_SYSFS;

--- a/multipathd/cli_handlers.c
+++ b/multipathd/cli_handlers.c
@@ -729,7 +729,8 @@ cli_add_map (void * v, char ** reply, int * len, void * data)
 			rc = get_refwwid(CMD_NONE, param, DEV_DEVMAP,
 					 vecs->pathvec, &refwwid);
 			if (refwwid) {
-				if (coalesce_paths(vecs, NULL, refwwid, 0, 1))
+				if (coalesce_paths(vecs, NULL, refwwid,
+						   FORCE_RELOAD_NONE, 1))
 					condlog(2, "%s: coalesce_paths failed",
 									param);
 				dm_lib_release();

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -526,7 +526,8 @@ ev_add_map (char * dev, char * alias, struct vectors * vecs)
 	r = get_refwwid(CMD_NONE, dev, DEV_DEVMAP, vecs->pathvec, &refwwid);
 
 	if (refwwid) {
-		r = coalesce_paths(vecs, NULL, refwwid, 0, CMD_NONE);
+		r = coalesce_paths(vecs, NULL, refwwid, FORCE_RELOAD_NONE,
+				   CMD_NONE);
 		dm_lib_release();
 	}
 
@@ -1887,6 +1888,7 @@ configure (struct vectors * vecs, int start_waiters)
 	vector mpvec;
 	int i, ret;
 	struct config *conf;
+	static int force_reload = FORCE_RELOAD_WEAK;
 
 	if (!vecs->pathvec && !(vecs->pathvec = vector_alloc()))
 		return 1;
@@ -1920,8 +1922,14 @@ configure (struct vectors * vecs, int start_waiters)
 
 	/*
 	 * create new set of maps & push changed ones into dm
+	 * In the first call, use FORCE_RELOAD_WEAK to avoid making
+	 * superfluous ACT_RELOAD ioctls. Later calls are done
+	 * with FORCE_RELOAD_YES.
 	 */
-	if (coalesce_paths(vecs, mpvec, NULL, 1, CMD_NONE))
+	ret = coalesce_paths(vecs, mpvec, NULL, force_reload, CMD_NONE);
+	if (force_reload == FORCE_RELOAD_WEAK)
+		force_reload = FORCE_RELOAD_YES;
+	if (ret)
 		return 1;
 
 	/*

--- a/multipathd/main.c
+++ b/multipathd/main.c
@@ -2249,6 +2249,10 @@ child (void * param)
 		conf->verbosity = verbosity;
 	if (bindings_read_only)
 		conf->bindings_read_only = bindings_read_only;
+	if (conf->find_multipaths) {
+		condlog(2, "find_multipaths is set: -n is implied");
+		ignore_new_devs = 1;
+	}
 	if (ignore_new_devs)
 		conf->ignore_new_devs = ignore_new_devs;
 	uxsock_timeout = conf->uxsock_timeout;

--- a/multipathd/multipathd.service
+++ b/multipathd/multipathd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Wants=systemd-udev-trigger.service systemd-udev-settle.service
-Before=iscsi.service iscsid.service lvm2-lvmetad.service lvm2-activation.service
+Before=iscsi.service iscsid.service lvm2-lvmetad.service lvm2-activation-early.service
 Before=local-fs-pre.target blk-availability.service
 After=multipathd.socket systemd-udev-trigger.service systemd-udev-settle.service
 DefaultDependencies=no


### PR DESCRIPTION
Fixes for:
bsc#991432, bsc#986838, bsc#1012910, (#1-#4)
bsc#998906, bsc#998893, bsc#1005763, bsc#1011400 (#5-#15, the successful tests by HP were done with a slightly different version; this is the code to minimize ioctls from coalesce_paths())
bsc#1019181 (#16)

