### PR TITLE
libmultipath/propsel: fix compiler warnings

### DIFF
--- a/libmultipath/propsel.c
+++ b/libmultipath/propsel.c
@@ -380,7 +380,7 @@ static int
 check_rdac(struct path * pp)
 {
 	int len;
-	unsigned char buff[44];
+	char buff[44];
 
 	len = get_vpd_sgio(pp->fd, 0xC9, buff, 44);
 	if (len <= 0)


### PR DESCRIPTION
propsel.c: In function ‘check_rdac’:
propsel.c:385:35: warning: pointer targets in passing argument 3 of ‘get_vpd_sgio’ differ in signedness [-Wpointer-sign]
  len = get_vpd_sgio(pp->fd, 0xC9, buff, 44);
                                   ^~~~
In file included from propsel.c:19:0:
discovery.h:38:5: note: expected ‘char *’ but argument is of type ‘unsigned char *’
 int get_vpd_sgio (int fd, int pg, char * str, int maxlen);
