### PR TITLE
Build: properly parse systemd's version

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -37,7 +37,7 @@ endif
 
 ifndef SYSTEMD
 	ifeq ($(shell systemctl --version > /dev/null 2>&1 && echo 1), 1)
-		SYSTEMD = $(shell systemctl --version 2> /dev/null |  sed -n 's/systemd \([0-9]*\)/\1/p')
+		SYSTEMD = $(shell systemctl --version 2> /dev/null |  sed -n 's/systemd \([0-9]*\).*/\1/p')
 	endif
 endif
 


### PR DESCRIPTION
Since systemd 241, systemctl --version no longer 'just' prints out the version, but gives more information like git commit ref and whatnot. In it's shortest form, it gives something like "systemd 241 (241)", which when passed as parameter "-DUSE_SYSTEMD=241 (241)" results in shell errors.

The provided fix is the shortest possible, by simply acknoledging that there MIGHT be more behind the number, which we do not further parse.

A more correct, but more complex solution would be to switch to using pkg-config and extract the version from the provided .pc files.