### PR TITLE
libdmmp: Fix undefined TRUE

### DIFF
--- a/libdmmp/libdmmp_private.h
+++ b/libdmmp/libdmmp_private.h
@@ -82,7 +82,7 @@ static out_type func_name(struct dmmp_context *ctx, const char *var_name) { \
 do { \
 	json_type j_type = json_type_null; \
 	json_object *j_obj_tmp = NULL; \
-	if (json_object_object_get_ex(j_obj, key, &j_obj_tmp) != TRUE) { \
+	if (!json_object_object_get_ex(j_obj, key, &j_obj_tmp)) { \
 		_error(ctx, "Invalid JSON output from multipathd IPC: " \
 		       "key '%s' not found", key); \
 		rc = DMMP_ERR_IPC_ERROR; \


### PR DESCRIPTION
Fixes the following issue:

In file included from libdmmp.c:37:
libdmmp.c: In function 'dmmp_mpath_array_get':
libdmmp_private.h:85:59: error: 'TRUE' undeclared (first use in this function)
   85 |  if (json_object_object_get_ex(j_obj, key, &j_obj_tmp) != TRUE) { \
      |                                                           ^~~~
libdmmp.c:205:2: note: in expansion of macro '_json_obj_get_value'
  205 |  _json_obj_get_value(ctx, j_obj, cur_json_major_version,
      |  ^~~~~~~~~~~~~~~~~~~
libdmmp_private.h:85:59: note: each undeclared identifier is reported only once for each function it appears in
   85 |  if (json_object_object_get_ex(j_obj, key, &j_obj_tmp) != TRUE) { \
      |                                                           ^~~~
libdmmp.c:205:2: note: in expansion of macro '_json_obj_get_value'
  205 |  _json_obj_get_value(ctx, j_obj, cur_json_major_version,
      |  ^~~~~~~~~~~~~~~~~~~
make[1]: *** [../Makefile.inc:132: libdmmp.o] Error 1

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>