### PR TITLE
libmultipath: fix creating install dir

### DIFF
--- a/libmultipath/checkers/Makefile
+++ b/libmultipath/checkers/Makefile
@@ -24,6 +24,7 @@ libcheck%.so: %.o
 	$(CC) $(LDFLAGS) $(SHARED_FLAGS) -o $@ $^
 
 install:
+	$(INSTALL_PROGRAM) -d $(DESTDIR)$(libdir)
 	$(INSTALL_PROGRAM) -m 755 $(LIBS) $(DESTDIR)$(libdir)
 
 uninstall:

--- a/libmultipath/prioritizers/Makefile
+++ b/libmultipath/prioritizers/Makefile
@@ -35,6 +35,7 @@ libprio%.so: %.o
 	$(CC) $(LDFLAGS) $(SHARED_FLAGS) -o $@ $^
 
 install: $(LIBS)
+	$(INSTALL_PROGRAM) -d $(DESTDIR)$(libdir)
 	$(INSTALL_PROGRAM) -m 755 libprio*.so $(DESTDIR)$(libdir)
 
 uninstall:


### PR DESCRIPTION
The 'install' command fails if the target directory doesn't exit.

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>