### PR TITLE
OBS CI test from command line

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,5 +1,5 @@
 workflow:
   steps:
     - branch_package:
-        source_project: Base:System
+        source_project: home:mwilck:multipath
         source_package: multipath-tools


### PR DESCRIPTION
- libmultipath: add timespeccmp() utility function
- libmultipath: add trylock() helper
- libmultipath: add optional wakeup functionality to lock.c
- libmultipath: print: add __snprint_config()
- libmultipath: improve cleanup of uevent queues on exit
- multipathd: fix systemd notification when stopping while reloading
- multipathd: improve delayed reconfigure
- multipathd: cli.h: formatting improvements
- multipathd: cli_del_map: fix reply for delayed action
- multipathd: add prototype for cli_handler functions
- multipathd: make all cli_handlers static
- multipathd: add and set cli_handlers in a single step
- multipathd: cli.c: use ESRCH for "command not found"
- multipathd: add "force_reconfigure" option
- multipathd: uxlsnr: avoid stalled clients during reconfigure
- multipathd: uxlsnr: handle client HUP
- multipathd: uxlsnr: use symbolic values for pollfd indices
- multipathd: uxlsnr: avoid using fd -1 in ppoll()
- multipathd: uxlsnr: data structure for stateful client connection
- multipathd: move uxsock_trigger() to uxlsnr.c
- multipathd: move parse_cmd() to uxlsnr.c
- multipathd: uxlsnr: remove check_timeout()
- multipathd: uxlsnr: move client handling to separate function
- multipathd: uxlsnr: use main poll loop for receiving
- multipathd: use strbuf in cli_handler functions
- multipathd: uxlsnr: check root on connection startup
- multipathd: uxlsnr: pass struct client to uxsock_trigger() and parse_cmd()
- multipathd: uxlsnr: move handler execution to separate function
- multipathd: uxlsnr: use parser to determine non-root commands
- multipathd: uxlsnr: merge uxsock_trigger() into state machine
- multipathd: uxlsnr: add idle notification
- multipathd: uxlsnr: add timeout handling
- multipathd: uxlsnr: use poll loop for sending, too
- multipathd: uxlsnr: drop client_lock
- multipathd: uxclt: allow client mode for non-root, too
- Added fossology assessment as README.licenses
- libmultipath: compat support for 'features "1 no_partitions"'
- multipath.conf.5: document no_partitons compat support
- kpartx: create symlinks for dmraid devices
- multipath.rules: temporary rule to obtain ID_WWN for NVMe
- change default for find_multipaths to "greedy"
- libmultipath: change partition_delimiter default to "-part"
- multipath -U: reduce log level of "adding new path" message
- Github workflows: add CI for SUSE-specific branches
- github workflows: add SUSE CI
- github workflows: enable SLE tests for factory/next, too
- OBS: add .obs/workflow.yml
- .obs/workflows.yml: use home:mwilck:multipath as base project
