### PR TITLE
offline paths

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -3,3 +3,4 @@ workflow:
     - branch_package:
         source_project: home:mwilck:multipath
         source_package: multipath-tools
+        target_project: home:mwilck


### PR DESCRIPTION
- Remove duplicate words, double spaces
- multipathd.service: add dependency on systemd-udevd-kernel.socket
- multipath-tools: generate abi with dummy version script
- multipath-tools: github abi workflow: don't fail on reference branch
- multipath-tools: github workflows: rebuild containers for rolling distros
- multipath tools: github workflows: add coverity workflow
- multipath-tools: .mailmap: add some more entries Reviewed-by: Benjamin Marzinski <bmarzins@redhat.com>
- libmultipath: make orphan_paths() static
- libmultipath: make update_pathvec_from_dm() static
- libmultipath: remove recv_packet_from_client()
- libmultipath.version: drop some unused symbols
- libmultipath.version: sort symbols
- Bump version to 0.8.8
- multipathd.service: remove LimitCORE=infinity directive
- multipathd.service: don't load SCSI device handler modules
- multipathd.service: add dependency on initrd-cleanup.service
- multipathd.service: drop dependencies on iscsi and iscsid
- libmultipath: embed dm_info in multipath structure
- multipathd: update dm_info on multipath change events
- multipathd: avoid unnecessary path read-only reloads
- libmpathpersist: split public and internal API
- multipathd: remove duplicate definitions from main.h
- libmpathpersist/multipathd: remove duplicate definition
- libmpathpersist: remove __STDC_FORMAT_MACROS
- libmpathpersist: cleanup mpathpr.h
- multipath-tools: fix misspellings
- libmultipath: always set ACT_RELOAD in reload_map()
- libmultipath: call verify_paths() in reload_map()
- libmultipath: drop drop_multipath()
- libmultipath: add vector_append_slot() helper
- libmultipath: use vector_append_slot() in add_pathgroup()
- libmultipath-tools: make all pgpolicy functions static
- libmultipath: add new_pg field to struct multipath
- libmultipath: remove free_paths argument from free_multipathvec()
- libmultipath: remove free_paths argument from free_multipath()
- libmultipath: remove free_paths argument from free_pgvec()
- libmultipath: add "mapped" field to struct path
- libmultipath: remove free_paths argument from free_pathgroup()
- libmultipath: group_paths(): always split paths
- libmultipath: change argument of select_path_group() to vector
- libmultipath: setup map using the new_pg field
- libmultipath: filter paths when creating path groups
- Added fossology assessment as README.licenses
- libmultipath: compat support for 'features "1 no_partitions"'
- multipath.conf.5: document no_partitons compat support
- kpartx: create symlinks for dmraid devices
- multipath.rules: temporary rule to obtain ID_WWN for NVMe
- change default for find_multipaths to "greedy"
- libmultipath: change partition_delimiter default to "-part"
- multipath -U: reduce log level of "adding new path" message
- Github workflows: add CI for SUSE-specific branches
- github workflows: add SUSE CI
- github workflows: enable SLE tests for factory/next, too
- OBS: add .obs/workflow.yml
- .obs/workflows.yml: use home:mwilck:multipath as base project
