### PR TITLE
tests: fix tests when built against cmocka 1.1.8 or newer

### DIFF
--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -1,6 +1,7 @@
 #include <setjmp.h>
 #include <stddef.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <cmocka.h>


### PR DESCRIPTION
CMocka 1.1.8  udate check for uintptr_t
Without including stdint, the test fails to compile (using GCC15) with

```
 In file included from test-log.c:6:
 test-log.c: In function ‘__wrap_dlog’:
 test-log.c:23:20: error: ‘uintptr_t’ undeclared (first use in this function)
    23 |         expected = mock_ptr_type(char *);
       |                    ^~~~~~~~~~~~~
 test-log.c:10:1: note: ‘uintptr_t’ is defined in header ‘<stdint.h>’; this is probably fixable by adding ‘#include <stdint.h>’
     9 | #include "debug.h"
   +++ |+#include <stdint.h>
    10 |
 test-log.c:23:20: note: each undeclared identifier is reported only once for each function it appears in
    23 |         expected = mock_ptr_type(char *);
       |                    ^~~~~~~~~~~~~
 test-log.c:23:20: error: expected ‘)’ before ‘_mock’
    23 |         expected = mock_ptr_type(char *);
       |                    ^~~~~~~~~~~~~
 test-log.c:23:20: note: to match this ‘(’
    23 |         expected = mock_ptr_type(char *);
       |                    ^~~~~~~~~~~~~
```